### PR TITLE
Cread/Edit/Delete boards from home screen

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -94,13 +94,11 @@ class BoardController extends Controller
             'width' => 'integer|required'
         ]);
 
-        $board = Board::find($board_id);
-
-        if ($board->user()->get()->id !== $user->id) {
-            return response("Cannot edit other user's board", 403);
+        if (!$board = $user->boards()->find($board_id)) {
+            return response("Board not found.", 404);
         }
 
-        $board->fill($validated);
+        $board->fill($validated)->save();
 
         return redirect('/home')->with('success', 'Board updated.');
     }

--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -48,15 +48,17 @@ class BoardController extends Controller
     // FIXME make sure only owner of board can delete
     public function deleteBoard(Request $request, int $board_id)
     {
-        $board = Board::find($board_id);
+        if (!$user = Auth::user()) {
+            return redirect('/login');
+        }
 
-        if (!$board) {
-            return response("Board $board_id not found", 404);
+        if (!$board = $user->boards->find($board_id)) {
+            return response('Board not found.', 404);
         }
 
         $board->delete();
 
-        return redirect('/home');
+        return redirect('/home')->with('success', "{$board->name} deleted.");
     }
 
     public function createBoard()
@@ -75,7 +77,7 @@ class BoardController extends Controller
             'height' => 5,
         ]);
 
-        return redirect('/home');
+        return redirect('/home')->with('success', "Blank board created.");
     }
 
     public function editBoard(Request $request, int $board_id)
@@ -98,8 +100,8 @@ class BoardController extends Controller
             return response("Cannot edit other user's board", 403);
         }
 
-        $board->fill($validated)->save();
+        $board->fill($validated);
 
-        return redirect('/home');
+        return redirect('/home')->with('success', 'Board updated.');
     }
 }

--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Board;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class BoardController extends Controller
 {
@@ -57,8 +58,22 @@ class BoardController extends Controller
         return redirect('/home');
     }
 
-    public function createBoard(Request $request)
+    public function createBoard()
     {
-        $board = Board::create();
+        $user = Auth::user();
+
+        if (!$user) {
+            return redirect('/login');
+        }
+
+        // FIXME we can create copies of boards with `Board::replicate`, but
+        // copying all the associated folders/words is insanely gnarly
+        $user->boards()->create([
+            'name' => 'Blank board',
+            'width' => 5,
+            'height' => 5,
+        ]);
+
+        return redirect('/home');
     }
 }

--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -45,6 +45,7 @@ class BoardController extends Controller
         return view('board', ['board_id' => $board_id]);
     }
 
+    // FIXME make sure only owner of board can delete
     public function deleteBoard(Request $request, int $board_id)
     {
         $board = Board::find($board_id);
@@ -73,6 +74,31 @@ class BoardController extends Controller
             'width' => 5,
             'height' => 5,
         ]);
+
+        return redirect('/home');
+    }
+
+    public function editBoard(Request $request, int $board_id)
+    {
+        $user = Auth::user();
+
+        if (!$user) {
+            return redirect('/login');
+        }
+
+        $validated = $request->validate([
+            'name' => 'string|required',
+            'height' => 'integer|required',
+            'width' => 'integer|required'
+        ]);
+
+        $board = Board::find($board_id);
+
+        if ($board->user()->get()->id !== $user->id) {
+            return response("Cannot edit other user's board", 403);
+        }
+
+        $board->fill($validated)->save();
 
         return redirect('/home');
     }

--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -43,4 +43,22 @@ class BoardController extends Controller
     {
         return view('board', ['board_id' => $board_id]);
     }
+
+    public function deleteBoard(Request $request, int $board_id)
+    {
+        $board = Board::find($board_id);
+
+        if (!$board) {
+            return response("Board $board_id not found", 404);
+        }
+
+        $board->delete();
+
+        return redirect('/home');
+    }
+
+    public function createBoard(Request $request)
+    {
+        $board = Board::create();
+    }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,7 +10,7 @@ class HomeController extends Controller
     {
         $user = $request->user();
 
-        $boards = [(object) ['id' => 1, 'name' => 'Default board']];
+        $boards = $user->boards()->get();
 
         return view('home', [
             'name' => $user->name,

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,7 +10,7 @@ class HomeController extends Controller
     {
         $user = $request->user();
 
-        $boards = $user->boards()->get();
+        $boards = $user->boards()->get()->sortBy('id');
 
         return view('home', [
             'name' => $user->name,

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -3,9 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Board extends Model
+class Board extends TileContainer
 {
     use HasFactory;
 
@@ -38,34 +37,6 @@ class Board extends Model
         'folders'
     ];
 
-    // append this custom field to the serialized JSON
-    protected $appends = [
-        'contents'
-    ];
-
-    // when this model gets serialized w/ toArray, a field called `contents`
-    // will be populated with the result of this function
-    public function getContentsAttribute()
-    {
-        $contents = $this->folders()->get()->concat($this->words()->get());
-
-        $content_rows = $contents->groupBy(
-            fn ($item) => $item->pivot->board_y
-        )->sortKeys()->values();
-
-        $sorted_rows = $content_rows->map(
-            fn ($row) => $row->sortBy(fn ($item) => $item->pivot->board_x)
-        );
-
-        $expanded_sorted_contents = $sorted_rows->map(function ($row) {
-            return $row->map(function ($item) {
-                return $item->toArray();
-            })->sortKeys()->values();
-        });
-
-        return $expanded_sorted_contents->toArray();
-    }
-
     public function words()
     {
         return $this->belongsToMany(
@@ -93,5 +64,12 @@ class Board extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function createCopy(): Board
+    {
+        $replicant = $this->replicate();
+
+        return $replicant;
     }
 }

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -3,9 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Folder extends Model
+class Folder extends TileContainer
 {
     use HasFactory;
 
@@ -38,11 +37,6 @@ class Folder extends Model
         'folders'
     ];
 
-    // append this custom field to the serialized JSON
-    protected $appends = [
-        'contents'
-    ];
-
     public function words()
     {
         return $this->belongsToMany(
@@ -60,29 +54,6 @@ class Folder extends Model
             'outer_folder_id',
             'inner_folder_id'
         )->withPivot('board_x', 'board_y');
-    }
-
-    // when this model gets serialized w/ toArray, a field called `contents`
-    // will be populated with the result of this function
-    public function getContentsAttribute()
-    {
-        $contents = $this->folders()->get()->concat($this->words()->get());
-
-        $content_rows = $contents->groupBy(
-            fn ($item) => $item->pivot->board_y
-        )->sortKeys()->values();
-
-        $sorted_rows = $content_rows->map(
-            fn ($row) => $row->sortBy(fn ($item) => $item->pivot->board_x)
-        );
-
-        $expanded_sorted_contents = $sorted_rows->map(function ($row) {
-            return $row->map(function ($item) {
-                return $item->toArray();
-            })->sortKeys()->values();
-        });
-
-        return $expanded_sorted_contents->toArray();
     }
 
     public function user()

--- a/app/Models/TileContainer.php
+++ b/app/Models/TileContainer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TileContainer extends Model
+{
+    // append this custom field to the serialized JSON
+    protected $appends = [
+        'contents'
+    ];
+
+    // when this model gets serialized w/ toArray, a field called `contents`
+    // will be populated with the result of this function
+    public function getContentsAttribute()
+    {
+        $contents = $this->folders()->get()->concat($this->words()->get());
+
+        $content_rows = $contents->groupBy(
+            fn ($item) => $item->pivot->board_y
+        )->sortKeys()->values();
+
+        $sorted_rows = $content_rows->map(
+            fn ($row) => $row->sortBy(fn ($item) => $item->pivot->board_x)
+        );
+
+        $expanded_sorted_contents = $sorted_rows->map(function ($row) {
+            return $row->map(function ($item) {
+                return $item->toArray();
+            })->sortKeys()->values();
+        });
+
+        return $expanded_sorted_contents->toArray();
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,6 +7,8 @@
   @foreach ($boards as $board)
     <li>
       <a href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
+      <a href="/boards/{{ $board->id }}/delete"> Delete </a>
+      <a href="/boards/{{ $board->id }}/edit"> Edit </a>
     </li>
   @endforeach
   <ul>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -3,11 +3,19 @@
   <a href="/logout">Logout</a>
   <a href="/user-settings">Settings</a>
 
+  <form action="/boards/create" method="POST">
+    @csrf
+    <button type="submit">Create Board</button>
+  </form>
   <ul>
   @foreach ($boards as $board)
     <li>
       <a href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
-      <a href="/boards/{{ $board->id }}/delete"> Delete </a>
+      <form action="/boards/{{ $board->id }}/delete" method="POST">
+        @method('DELETE')
+        @csrf
+        <button type="submit">Delete</button>
+      </form>
       <a href="/boards/{{ $board->id }}/edit"> Edit </a>
     </li>
   @endforeach

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,23 +1,39 @@
 <html>
-  <p>You are logged in as {{ $name }}.</p>
-  <a href="/logout">Logout</a>
-  <a href="/user-settings">Settings</a>
+  <head>
+    <title>Lucy - Home</title>
+  </head>
+  <body>
+    <p>You are logged in as {{ $name }}.</p>
+    <a href="/logout">Logout</a>
+    <a href="/user-settings">Settings</a>
 
-  <form action="/boards/create" method="POST">
-    @csrf
-    <button type="submit">Create Board</button>
-  </form>
-  <ul>
-  @foreach ($boards as $board)
-    <li>
-      <a href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
-      <form action="/boards/{{ $board->id }}/delete" method="POST">
-        @method('DELETE')
-        @csrf
-        <button type="submit">Delete</button>
-      </form>
-      <a href="/boards/{{ $board->id }}/edit"> Edit </a>
-    </li>
-  @endforeach
-  <ul>
+    <form action="/boards" method="POST">
+      @csrf
+      <button type="submit">Create Board</button>
+    </form>
+    <ul>
+    @foreach ($boards as $board)
+      <li>
+        <a href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
+        <form action="/boards/{{ $board->id }}" method="POST">
+          @method('DELETE')
+          @csrf
+          <button type="submit">Delete</button>
+        </form>
+        <button onclick="document.getElementById('modal-{{ $board->id }}').style.display='block'"> Edit </button>
+        <div id="modal-{{ $board->id }}" style="display: none;">
+          <button onclick="document.getElementById('modal-{{ $board->id }}').style.display='none'">Close &times;</button>
+          <form action="/boards/{{$board->id}}" method="POST">
+            @method('PUT')
+            @CSRF
+            <input type="text" name="name" value="{{$board->name}}" />
+            <input type="number" min="1" max="10" name="height" value="{{$board->height}}" />
+            <input type="number" min="1" max="10" name="width" value="{{$board->width}}" />
+            <button type="submit">Save</button>
+          </form>
+        </div>
+      </li>
+    @endforeach
+    <ul>
+  </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,9 @@ Route::get('/home', [HomeController::class, 'index'])
 // fetched by React and returns json, do not need views
 Route::get('/users/{user_id}/boards', [BoardController::class, 'getUserBoards']);
 Route::get('/boards/{board_id}', [BoardController::class, 'getBoard']);
+Route::delete('/boards/{board_id}/delete', [BoardController::class, 'deleteBoard']);
+Route::put('/boards/{board_id}/delete', [BoardController::class, 'editBoard']);
+Route::post('/boards/{board_id}/delete', [BoardController::class, 'createBoard']);
 Route::redirect('/guest', '/boards/1'); // default board
 Route::get('/boards/{board_id}/tiles', [BoardController::class, 'getBoardTiles']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,9 +42,9 @@ Route::get('/home', [HomeController::class, 'index'])
     ->middleware(['auth']);
 
 Route::get('/boards/{board_id}', [BoardController::class, 'getBoard']);
-Route::delete('/boards/{board_id}/delete', [BoardController::class, 'deleteBoard']);
-Route::put('/boards/{board_id}/edit', [BoardController::class, 'editBoard']);
-Route::post('/boards/create', [BoardController::class, 'createBoard']);
+Route::delete('/boards/{board_id}', [BoardController::class, 'deleteBoard']);
+Route::put('/boards/{board_id}', [BoardController::class, 'editBoard']);
+Route::post('/boards', [BoardController::class, 'createBoard']);
 Route::redirect('/guest', '/boards/1'); // default board
 
 // fetched by React and returns json, do not need views

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,14 +41,15 @@ Route::get('/home', [HomeController::class, 'index'])
     ->name('home')
     ->middleware(['auth']);
 
-// fetched by React and returns json, do not need views
-Route::get('/users/{user_id}/boards', [BoardController::class, 'getUserBoards']);
 Route::get('/boards/{board_id}', [BoardController::class, 'getBoard']);
 Route::delete('/boards/{board_id}/delete', [BoardController::class, 'deleteBoard']);
-Route::put('/boards/{board_id}/delete', [BoardController::class, 'editBoard']);
-Route::post('/boards/{board_id}/delete', [BoardController::class, 'createBoard']);
+Route::put('/boards/{board_id}/edit', [BoardController::class, 'editBoard']);
+Route::post('/boards/create', [BoardController::class, 'createBoard']);
 Route::redirect('/guest', '/boards/1'); // default board
+
+// fetched by React and returns json, do not need views
 Route::get('/boards/{board_id}/tiles', [BoardController::class, 'getBoardTiles']);
+Route::get('/users/{user_id}/boards', [BoardController::class, 'getUserBoards']);
 
 Route::get('/words/{id}', [WordController::class, 'getWords']);
 Route::get('/words/user/{id}', [WordController::class, 'getUserWords']);

--- a/tests/Feature/BoardControllerTest.php
+++ b/tests/Feature/BoardControllerTest.php
@@ -135,4 +135,35 @@ class BoardControllerTest extends TestCase
 
         $response->assertRedirectContains('/login');
     }
+
+    public function test_user_can_edit_board()
+    {
+        $board = Board::factory()->for($this->user)->create();
+
+        $response = $this->get("/boards/{$board->id}/tiles");
+
+        $response->assertJson([
+            'name' => $board->name,
+            'height' => $board->height,
+            'width' => $board->width
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->putJson("/boards/{$board->id}", [
+                'name' => 'New name',
+                'height' => $board->height + 1,
+                'width' => $board->width - 1
+            ]);
+
+        $response->assertRedirectContains('/home');
+        $response->assertSessionHas('success');
+
+        $response = $this->get("/boards/{$board->id}/tiles");
+
+        $response->assertJson([
+            'name' => 'New name',
+            'height' => $board->height + 1,
+            'width' => $board->width - 1
+        ]);
+    }
 }


### PR DESCRIPTION
Closes #75 

no JS/DB changes for this, so just pull the branch and you should see the changes when you create an account and log in. from the home screen you can create blank boards (making copies of the default board/other boards will be addressed in #77 ).

editing/deleting should work as expected - you can double-check updating the board names by clicking the board links and going to the board screen. in the folder path above the sentence bar, you should see your updated board name.