### PR TITLE
Create Docker volume for `vendor`, `node_modules`

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,6 +7,8 @@ services:
       - database
     volumes:
       - ./:/var/www/html
+      - /var/www/html/vendor
+      - /var/www/html/node_modules
     ports:
       - 8080:80
 


### PR DESCRIPTION
Prevents local `vendor` and `node_module` directories from overwriting the `vendor` and `node_module` directories created by the Dockerfile.