### PR TITLE
fixed bug by making the color nullable in the create words table

### DIFF
--- a/database/migrations/2021_12_07_020133_create_words_table.php
+++ b/database/migrations/2021_12_07_020133_create_words_table.php
@@ -21,7 +21,7 @@ class CreateWordsTable extends Migration
 
             $table->text('text');
             $table->binary('icon')->nullable();
-            $table->text('color')->default('#FFFFFF');
+            $table->text('color')->nullable()->default('#FFFFFF');
 
             $table->timestamps();
         });


### PR DESCRIPTION
make sure to run docker-compose exec app php artisan migrate:fresh --seed

Users can now add a new word without needing to specify a color.