### PR TITLE
Color validation

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -91,8 +91,8 @@ class BoardController extends Controller
     public function addTileToBoard(Request $request, int $board_id)
     {
         $board = Board::find($board_id);
-
-        if ($request->color)
+        
+        if ($request->color != null)
         {
             $request->validate(['color' => new hex_color]);
         }
@@ -113,7 +113,7 @@ class BoardController extends Controller
     public function editTileFromBoard(Request $request, int $board_id)
     {
         $type = $request->tileType;
-        $tileId = $request->tileId;     
+        $tileId = $request->tileId;
 
         if ($type == 'word') {
             $tile = Word::find($tileId);
@@ -128,8 +128,7 @@ class BoardController extends Controller
             }
         }
 
-        if ($request->color) {
-            
+        if ($request->color != null) {
             $request->validate(['color' => new hex_color]);
             $tile->color = $request->color;
         }

--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidException;
+use App\Rules\hex_color;
 
 class BoardController extends Controller
 {
@@ -91,6 +92,11 @@ class BoardController extends Controller
     {
         $board = Board::find($board_id);
 
+        if ($request->color)
+        {
+            $request->validate(['color' => new hex_color]);
+        }
+
         $word = $board->user()->first()->words()->create([
             'text' => $request->get('text'),
             'color' => $request->get('color')
@@ -107,7 +113,7 @@ class BoardController extends Controller
     public function editTileFromBoard(Request $request, int $board_id)
     {
         $type = $request->tileType;
-        $tileId = $request->tileId;
+        $tileId = $request->tileId;     
 
         if ($type == 'word') {
             $tile = Word::find($tileId);
@@ -123,6 +129,8 @@ class BoardController extends Controller
         }
 
         if ($request->color) {
+            
+            $request->validate(['color' => new hex_color]);
             $tile->color = $request->color;
         }
 

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -84,6 +84,11 @@ class FolderController extends Controller
     {
         $folder = Folder::find($folder_id);
 
+        if ($request->color != null)
+        {
+            $request->validate(['color' => new hex_color]);
+        }
+
         $word = $folder->user()->first()->words()->create([
             'text' => $request->get('text'),
             'color' => $request->get('color')

--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -7,6 +7,7 @@ use App\Models\Folder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidException;
+use App\Rules\hex_color;
 
 class FolderController extends Controller
 {
@@ -51,6 +52,7 @@ class FolderController extends Controller
         }
 
         if ($request->color != null) {
+            $request->validate(['color' => new hex_color]);
             $tile->update(['color' => $request->color]);
         }
 

--- a/app/Rules/hex_color.php
+++ b/app/Rules/hex_color.php
@@ -26,7 +26,19 @@ class hex_color implements Rule
     public function passes($attribute, $value)
     {
         $value = strtolower($value);
-        $css_colors = array('black','silver','gray','white');
+        $css_colors = array('black','silver','gray','white', 'maroon', 'red', 'purple', 'fuchsia', 'green', 'lime', 'olive', 'yellow', 'navy', 
+        'blue', 'teal', 'aqua', 'aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet', 'brown', 'burlywood', 'cadetblue',
+        'chartreuse', 'chocolate', 'coral', 'cornflowerblue', '	cornsilk', 'crimson', 'cyan', 'darkblue','darkcyan', 'darkgoldenrod', '	darkgray', 'darkgreen', 'darkgrey',
+        'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey',
+        'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro', 'ghostwhite',
+        'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon',
+        'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
+        'lightslategray', '	lightslategrey', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid',
+        'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin',
+        'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip',
+        'peachpuff','peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue',
+        'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen	', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen'
+        );
 
         if (ctype_xdigit($value) and strlen($value)==6)
         {

--- a/app/Rules/hex_color.php
+++ b/app/Rules/hex_color.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class hex_color implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $value = strtolower($value);
+        $css_colors = array('black','silver','gray','white');
+
+        if (ctype_xdigit($value) and (strlen($value)==6))
+        {
+            return True;
+        }
+
+        if (in_array($value, $css_colors))
+        {
+            return True;
+        }
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'Color must be a 6 digit hexadecimal number or a valid css color.';
+    }
+}

--- a/app/Rules/hex_color.php
+++ b/app/Rules/hex_color.php
@@ -28,7 +28,7 @@ class hex_color implements Rule
         $value = strtolower($value);
         $css_colors = array('black','silver','gray','white');
 
-        if (ctype_xdigit($value) and (strlen($value)==6))
+        if (ctype_xdigit($value) and strlen($value)==6)
         {
             return True;
         }
@@ -37,6 +37,8 @@ class hex_color implements Rule
         {
             return True;
         }
+
+        return False;
     }
 
     /**

--- a/resources/js/components/Board.js
+++ b/resources/js/components/Board.js
@@ -325,7 +325,7 @@ export class Board extends React.Component {
         console.log(error_message)
         this.setState({
           errorModal: true,
-          errorMessage: error_message ,
+          errorMessage: error_message,
         })
       });
     }
@@ -348,6 +348,11 @@ export class Board extends React.Component {
         configuringTile: false,
         createModal: false
       }, this.fetchBoardTiles);
+    }).catch((error) => {
+      this.setState({
+        errorModal: true,
+        errorMessage: error.response.data.errors.color,
+      })
     });
   }
 

--- a/resources/js/components/Board.js
+++ b/resources/js/components/Board.js
@@ -320,9 +320,12 @@ export class Board extends React.Component {
           selectedFile: false
         }, this.fetchBoardTiles);
       }).catch((error) => {
+        const error_message = error.response.data.errors.image == 'undefined' ? 
+        error.response.data.errors.image : error.response.data.errors.color
+        console.log(error_message)
         this.setState({
           errorModal: true,
-          errorMessage: error.response.data.errors.image
+          errorMessage: error_message ,
         })
       });
     }

--- a/resources/js/components/Board.js
+++ b/resources/js/components/Board.js
@@ -322,7 +322,6 @@ export class Board extends React.Component {
       }).catch((error) => {
         const error_message = error.response.data.errors.image == 'undefined' ? 
         error.response.data.errors.image : error.response.data.errors.color
-        console.log(error_message)
         this.setState({
           errorModal: true,
           errorMessage: error_message,


### PR DESCRIPTION
When users enter a new color in the edit or add tile modals, it must be a valid css color or 6 digit hex number.

The input doesnt accept a # preceding the number anymore.