### PR TITLE
Allow users to export boards as `.obf` files

### DIFF
--- a/app/Http/Controllers/BoardController.php
+++ b/app/Http/Controllers/BoardController.php
@@ -6,6 +6,7 @@ use App\Models\Board;
 use App\Models\Word;
 use App\Models\User;
 use App\Models\Folder;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -201,5 +202,17 @@ class BoardController extends Controller
         $board->fill($validated)->save();
 
         return redirect('/home')->with('success', 'Board updated.');
+    }
+
+    public function exportBoard(Request $request, int $board_id)
+    {
+        $board = Board::find($board_id);
+
+        $obf_json = $board->exportToObf();
+
+        Storage::put("public/obf/{$board_id}/{$board->name}.obf",
+                     json_encode($obf_json, JSON_UNESCAPED_SLASHES));
+
+        return Storage::download("public/obf/{$board_id}/{$board->name}.obf");
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Board;
 use Illuminate\Http\Request;
 
 class HomeController extends Controller

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -64,12 +64,12 @@ class Board extends TileContainer
             })
             ->map( function($tile): array {
                 return [
-                    'id' => $tile->id,
+                    'id' => (string) $tile->id,
                     'url' => $tile->icon,
                     'height' => "76",
                     'width' => "76",
                     'content_type' => $tile->icon
-                        ? 'image/' . end(explode('.', $tile->icon))
+                        ? 'image/' . substr(strrchr($tile->icon, '.'), 1)
                         : null,
                 ];
             });
@@ -78,8 +78,8 @@ class Board extends TileContainer
             return [
                 // hack: folders and words share the same id space, so just make
                 // folder ids negative to prevent collisions
-                'id' => $tile->name ? -$tile->id : $tile->id,
-                'label' => $tile->text,
+                'id' => (string) ($tile->name ? -$tile->id : $tile->id),
+                'label' => $tile->name ?? $tile->text,
                 'border_color' => 'rbg(0, 0, 0)',
                 'background_color' => $tile->color,
                 'image_id' => $tile->id
@@ -104,8 +104,9 @@ class Board extends TileContainer
         ];
 
         return [
-            'format' => 'open-boiard-0.1',
-            'id' => $this->id,
+            'format' => 'open-board-0.1',
+            'locale' => 'en',
+            'id' => (string) $this->id,
             'url' => url("/boards/{$this->id}"),
             'name' => $this->name,
             'description' => 'Board created by Project Lucy',

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -72,7 +72,7 @@ class Board extends TileContainer
                         ? 'image/' . substr(strrchr($tile->icon, '.'), 1)
                         : null,
                 ];
-            });
+            })->values();
 
         $buttons = $this->tiles()->map( function($tile): array {
             return [
@@ -82,20 +82,24 @@ class Board extends TileContainer
                 'label' => $tile->name ?? $tile->text,
                 'border_color' => 'rbg(0, 0, 0)',
                 'background_color' => $tile->color,
-                'image_id' => $tile->id
+                'image_id' => (string) $tile->id
             ];
-        });
+        })->values();
 
         $grid_order = [];
 
         for ($y = 1; $y <= $this->height; $y++) {
             for ($x = 1; $x <= $this->width; $x++) {
-                $grid_order[$y][$x] = $this->tiles()
+                (string) $grid_order[$y][$x] = $this->tiles()
                     ->where('pivot.board_x', $x)
                     ->firstWhere('pivot.board_y', $y)
                     ?->id;
             }
+
+            $grid_order[$y] = array_values($grid_order[$y]);
         }
+
+        $grid_order = array_values($grid_order);
 
         $grid = [
             'rows' => $this->height,
@@ -112,7 +116,8 @@ class Board extends TileContainer
             'description' => 'Board created by Project Lucy',
             'images' => $images,
             'buttons' => $buttons,
-            'grid' => $grid
+            'grid' => $grid,
+            'sounds' => []
         ];
     }
 }

--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -46,11 +46,6 @@ class Board extends TileContainer
         )->withPivot('board_x', 'board_y');
     }
 
-    public function placeItem($item, $row, $column)
-    {
-        ///todo
-    }
-
     public function swapItems($rowA, $columnA, $rowB, $columnB)
     {
         ///todo
@@ -59,5 +54,64 @@ class Board extends TileContainer
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function exportToObf(): array
+    {
+        $images = $this->tiles()
+            ->filter( function($tile): bool {
+                return (bool) $tile->icon;
+            })
+            ->map( function($tile): array {
+                return [
+                    'id' => $tile->id,
+                    'url' => $tile->icon,
+                    'height' => "76",
+                    'width' => "76",
+                    'content_type' => $tile->icon
+                        ? 'image/' . end(explode('.', $tile->icon))
+                        : null,
+                ];
+            });
+
+        $buttons = $this->tiles()->map( function($tile): array {
+            return [
+                // hack: folders and words share the same id space, so just make
+                // folder ids negative to prevent collisions
+                'id' => $tile->name ? -$tile->id : $tile->id,
+                'label' => $tile->text,
+                'border_color' => 'rbg(0, 0, 0)',
+                'background_color' => $tile->color,
+                'image_id' => $tile->id
+            ];
+        });
+
+        $grid_order = [];
+
+        for ($y = 1; $y <= $this->height; $y++) {
+            for ($x = 1; $x <= $this->width; $x++) {
+                $grid_order[$y][$x] = $this->tiles()
+                    ->where('pivot.board_x', $x)
+                    ->firstWhere('pivot.board_y', $y)
+                    ?->id;
+            }
+        }
+
+        $grid = [
+            'rows' => $this->height,
+            'columns' => $this->width,
+            'order' => $grid_order
+        ];
+
+        return [
+            'format' => 'open-boiard-0.1',
+            'id' => $this->id,
+            'url' => url("/boards/{$this->id}"),
+            'name' => $this->name,
+            'description' => 'Board created by Project Lucy',
+            'images' => $images,
+            'buttons' => $buttons,
+            'grid' => $grid
+        ];
     }
 }

--- a/app/Models/TileContainer.php
+++ b/app/Models/TileContainer.php
@@ -13,9 +13,9 @@ class TileContainer extends Model
 
     // when this model gets serialized w/ toArray, a field called `contents`
     // will be populated with the result of this function
-    public function getContentsAttribute()
+    public function getContentsAttribute(): array
     {
-        $contents = $this->folders()->get()->concat($this->words()->get());
+        $contents = $this->tiles();
 
         $max_width = $contents->max('pivot.board_x');
         $max_height = $contents->max('pivot.board_y');
@@ -65,5 +65,9 @@ class TileContainer extends Model
         }
 
         return $replicant;
+    }
+
+    public function tiles() {
+        return $this->words()->get()->concat($this->folders()->get());
     }
 }

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -71,7 +71,15 @@
     gap: 20px;
     grid-template-columns: 2fr 1fr;
 }
-.home-board a
+
+.export-link {
+    text-decoration: none;
+    color: black;
+    margin-top: 20px;
+    transition: ease-out 0.15s;
+}
+
+.home-board-link
 {
     text-decoration: none;
     font-size: xxx-large;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -36,6 +36,9 @@
           <button type="submit">Delete</button>
         </form>
         <button onclick="document.getElementById('modal-{{ $board->id }}').style.display='block'"> Edit </button>
+        <button>
+          <a href="/boards/{{ $board->id }}/export" download>Export</a>
+        </button>
       </div>
 
       <div id="modal-{{ $board->id }}" style="display: none;">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -27,7 +27,7 @@
     @foreach ($boards as $board)
     <li class="home-board board-separator">
       <div>
-        <a href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
+        <a class="home-board-link" href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
       </div>
       <div>
         <form action="/boards/{{ $board->id }}" method="POST">
@@ -36,8 +36,8 @@
           <button type="submit">Delete</button>
         </form>
         <button onclick="document.getElementById('modal-{{ $board->id }}').style.display='block'"> Edit </button>
-        <button>
-          <a href="/boards/{{ $board->id }}/export" download>Export</a>
+        <button style="margin-top: 20px;">
+          <a class="export-link" href="/boards/{{ $board->id }}/export" download>Export</a>
         </button>
       </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ Route::get('/home', [HomeController::class, 'index'])
 Route::get('/boards/{board_id}', [BoardController::class, 'getBoard']);
 Route::delete('/boards/{board_id}', [BoardController::class, 'deleteBoard']);
 Route::put('/boards/{board_id}', [BoardController::class, 'editBoard']);
+Route::get('/boards/{board_id}/export', [BoardController::class, 'exportBoard']);
 Route::post('/boards', [BoardController::class, 'createBoard']);
 Route::redirect('/guest', '/boards/1'); // default board
 


### PR DESCRIPTION
Ran into a pretty big snag on this - there's no way to test that this works. I followed the [spec](https://www.openboardformat.org/docs#) to a T, and tried to use OpenAAC's `.obf` [validator](https://www.openboardformat.org/tools), but it looks like it's broken :/

I'm getting a vague `Cannot parse as JSON` error when I upload the file. I've triple checked, and the file that is downloaded is 100% a valid JSON blob. I can also see other users ([1](https://github.com/open-aac/openboardformat/issues/2), [2](https://github.com/open-aac/openboardformat/issues/1)) are having trouble with this.

Regardless, you can see the export link on the home screen right under the edit/delete links. Once you click that, you can inspect the downloaded file and see all the info.