### PR TITLE
Styling fixes

### DIFF
--- a/public/css/app-dark.css
+++ b/public/css/app-dark.css
@@ -1,5 +1,6 @@
 html {
     font-family: Arial, Helvetica, sans-serif;
+    color:black;
 }
 p
 {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -6,6 +6,7 @@
 }
 html {
     font-family: Helvetica, Arial, sans-serif;
+    color: black;
 }
 body {
     background-color: #b4b2c2; /* Default body background color */

--- a/public/css/board.css
+++ b/public/css/board.css
@@ -88,6 +88,7 @@
 
     text-align: var(--default-text-align);
     font-size: var(--default-font-size);
+    color: black;
 }
 .sentence-bar {
     height: var(--height-relative);

--- a/public/css/home-dark.css
+++ b/public/css/home-dark.css
@@ -71,7 +71,14 @@
     gap: 20px;
     grid-template-columns: 2fr 1fr;
 }
-.home-board a
+.export-link {
+    text-decoration: none;
+    color: black;
+    margin-top: 20px;
+    transition: ease-out 0.15s;
+}
+
+.home-board-link
 {
     text-decoration: none;
     font-size: xxx-large;
@@ -81,12 +88,11 @@
     border-radius: 10px;
     background-color: #EFEFEF;
     display: flex;
-    height:100%;
+    flex-grow: 1;
     align-items: center;
     justify-content: center;
     transition: ease-out 0.15s;
 }
-
 .home-board > div > button , .home-board > div > form > button
 {
     width: 100%;

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -89,7 +89,7 @@
     border-radius: 10px;
     background-color: #EFEFEF;
     display: flex;
-    height:100%;
+    flex-grow: 1;
     align-items: center;
     justify-content: center;
     transition: ease-out 0.15s;

--- a/resources/js/components/Board.js
+++ b/resources/js/components/Board.js
@@ -541,22 +541,28 @@ export class Board extends React.Component {
         <button className="settings-button" onClick={this.settingsButtonFunc}>Settings</button>
        
         <div style={{textAlign: "center"}}>
-        <table className="folder-path">
-        {paths}
-        </table>
-        <button disabled={ this.userIsOnBaseBoard() }
-                className="back-folder-button"
-                onClick={this.handleLastFolderButton}>
-          Last Folder
-        </button>
-        <button className="sentence-bar"
-                onClick={() => this.handleSpeakButtonClick(Event, audio_level)}>
-        <h2>{this.buildSentence()}</h2>
-        </button>
-        <button className="sentence-speak"
-                onClick={() => this.handleSpeakButtonClick(Event, audio_level)}>
-          Speak!
-        </button>
+          <div style={{"display": "flex", "justifyContent": "center"}}>
+            <table className="folder-path">
+              {paths}
+            </table>
+          </div>
+          
+          <div>
+            <button disabled={ this.userIsOnBaseBoard() }
+                    className="back-folder-button"
+                    onClick={this.handleLastFolderButton}>
+              Last Folder
+            </button>
+            <button className="sentence-bar"
+                    onClick={() => this.handleSpeakButtonClick(Event, audio_level)}>
+            <h2>{this.buildSentence()}</h2>
+            </button>
+            <button className="sentence-speak"
+                    onClick={() => this.handleSpeakButtonClick(Event, audio_level)}>
+              Speak!
+            </button>
+          </div>
+        
         </div>
         <br/>
         <WordSuggestions sentence={this.buildSentence() + ' '}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -37,7 +37,7 @@
         </form>
         <button onclick="document.getElementById('modal-{{ $board->id }}').style.display='block'"> Edit </button>
         <button style="margin-top: 20px;">
-          <a class="export-link" href="/boards/{{ $board->id }}/export" download>Export</a>
+          <a class="export-link" style="border: none;"href="/boards/{{ $board->id }}/export" download>Export</a>
         </button>
       </div>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -26,7 +26,7 @@
 
     @foreach ($boards as $board)
     <li class="home-board board-separator">
-      <div>
+      <div style="display: flex; flex-grow: 1;">
         <a class="home-board-link" href="/boards/{{ $board->id }}"> {{ $board->name }} </a>
       </div>
       <div>


### PR DESCRIPTION
The thing causing all the font styling issue on the mobile device was the `User Agent Style Sheet`. 
Explicitly setting the text color _should_ have fix it.

Other things fixed:
 - double border on export button in darkmode
 - back folder button font color
 - Board button height in home screen for Safari users
 - Fixed Folder Path not in middle of screen on phones
 
Most of these fixes require a phone to test, but I'm not quite sure how to go about that for you guys.
I used the Safari web dev tool on my phone and messed around with the css to get these fixes.