### PR TITLE
(Hotfix) Font color issue still persists on Iphones

### DIFF
--- a/public/css/app-dark.css
+++ b/public/css/app-dark.css
@@ -1,6 +1,5 @@
 html {
     font-family: Arial, Helvetica, sans-serif;
-    color:black;
 }
 p
 {
@@ -16,6 +15,7 @@ button {
     border-radius: 5px;
     box-shadow: inset 0 0 0 0 green;
     transition: ease-out 0.15s;
+    color: black;
 }
 button:hover {
     box-shadow: inset 0 0 100px 0 darkorange;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -6,7 +6,6 @@
 }
 html {
     font-family: Helvetica, Arial, sans-serif;
-    color: black;
 }
 body {
     background-color: #b4b2c2; /* Default body background color */
@@ -18,6 +17,7 @@ button { /* NOT the same as board tiles */
     text-align: center;
     box-shadow: inset 0 0 0 0 green;
     transition: ease-out 0.15s;
+    color: black;
 }
 button:hover { /* Default hover effect */
     box-shadow: inset 0 0 100px 0 rgb(32, 42, 178);
@@ -33,6 +33,7 @@ button:active:hover { /* Default click/touch hold effect*/
     font-size: x-large;
     margin-right: 15px;
     margin-top: 15px;
+    color: black;
 }
 .general-heading {
     text-align: center;

--- a/public/css/board.css
+++ b/public/css/board.css
@@ -108,6 +108,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    color: black;
 }
 .sentence-backspace {
     height: var(--height-relative);
@@ -118,6 +119,7 @@
     vertical-align: var(--vertical-align);
 
     background-color: #6c6fff;
+    color: black;
 
     border: var(--default-border);
     border-radius: var(--default-border-radius);
@@ -134,7 +136,8 @@
     vertical-align: var(--vertical-align);
 
     background-color:#d0f0ff;
-    
+    color: black;
+
     border: var(--default-border);
     border-radius: var(--default-border-radius);
 
@@ -150,6 +153,7 @@
     vertical-align: var(--vertical-align);
 
     background-color: #90eeac;
+    color: black;
 
     border: var(--default-border);
     border-radius: var(--default-border-radius);
@@ -192,6 +196,7 @@
 }
 .swap-button {
     background-color: aliceblue;
+    color: black;
 
     position: fixed;
     width: 10%;

--- a/public/css/home-dark.css
+++ b/public/css/home-dark.css
@@ -101,6 +101,7 @@
     font-size: xx-large;
     align-self: center;
     background-color: #EFEFEF ;
+    color: black;
     transition: ease-out 0.15s;
 }
 
@@ -120,7 +121,7 @@
     margin:auto;
     font-size: xx-large;
     align-self: center;
-
+    color: black;
     transition: ease-out 0.15s;
 }
 .home-create-board-button:hover

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -103,6 +103,7 @@
     font-size: xx-large;
     align-self: center;
     background-color: #EFEFEF ;
+    color: black;
     transition: ease-out 0.15s;
 }
 
@@ -123,7 +124,7 @@
     margin:auto;
     font-size: xx-large;
     align-self: center;
-
+    color: black;
     transition: ease-out 0.15s;
 }
 .home-create-board-button:hover

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -20,12 +20,19 @@
     margin-right: auto;
 }
 .update-settings-button { /*not actually a button element so need to keep some button css*/
-    background-color: var(--default-button-color);
+    background-color: lightgoldenrodyellow; /*Had to make it explicit for the dark mode to work properly*/
+    color: black;
     border-radius: 5px;
     border: 2px solid black;
     height: 50px;
     width: 70%;
     font-size: large;
+    transition: ease-out 0.15s;
+}
+.update-settings-button:hover { /* Default hover effect */
+    box-shadow: inset 0 0 100px 0 rgb(32, 42, 178);
+    color: white;
+    font-size: small;
 }
 .close-settings-button {
     height: 50px;


### PR DESCRIPTION
Turns out I have to be more explicit on the font color.
Just adding `color: black` to the `<html>` tag wasn't enough to fix the font issue on Iphones. The user agent style sheet was still overiding the css.
User agent stylesheet:
<img width="299" alt="Screen Shot 2022-04-26 at 9 41 27 PM" src="https://user-images.githubusercontent.com/64504438/165442457-8222db99-d0ee-4e2a-9a49-a621daecb621.png">

Html that is being overwritten:
<img width="313" alt="Screen Shot 2022-04-26 at 9 42 04 PM" src="https://user-images.githubusercontent.com/64504438/165442485-c7b5342e-c7a4-4a2b-8127-62081e6a4065.png">


So I had to go through and explicitly add them to each class to prevent the user agent style sheet from overiding it.