### PR TITLE
Ipad styling fixes

### DIFF
--- a/public/css/board.css
+++ b/public/css/board.css
@@ -164,6 +164,70 @@
     box-shadow: var(--default-box-shadow);
     transition: var(--default-transition);
 }
+/* makes the functionality buttons wider and reduces padding for ipad screens*/
+@media only screen and (max-width: 1536px) 
+{
+    .settings-button{
+        height: var(--height-relative);
+        width: 150px;
+    
+        margin: 5px;
+        margin-top: var(--vertical-margin);
+        vertical-align: var(--vertical-align);
+    
+        background-color:#56a495;
+        
+        border: var(--default-border);
+        border-radius: var(--default-border-radius);
+    
+        text-align: var(--default-text-align);
+        font-size: var(--default-font-size);
+        color: black;
+    }
+    .sentence-backspace {
+        height: var(--height-relative);
+        width: 150px;
+    
+        margin: 5px;
+        margin-top: var(--top-vertical-margin);
+        vertical-align: var(--vertical-align);
+    
+        background-color: #6c6fff;
+        color: black;
+    
+        border: var(--default-border);
+        border-radius: var(--default-border-radius);
+    
+        text-align: var(--default-text-align);
+        font-size: var(--default-font-size);
+    }
+    .sentence-clear {
+        height: var(--height-relative);
+        width: 150px;
+    
+        margin: 5px;
+        margin-top: var(--top-vertical-margin);
+        vertical-align: var(--vertical-align);
+    
+        background-color:#d0f0ff;
+        color: black;
+    
+        border: var(--default-border);
+        border-radius: var(--default-border-radius);
+    
+        text-align: var(--default-text-align);
+        font-size: var(--default-font-size);
+    }
+
+    .back-button {
+        width: 150px;
+        height: 12%;
+        font-size: x-large;
+        margin: 5px;
+        margin-top: var(--top-vertical-margin);
+        color: black;
+    }
+}
 .guest-default-board {
     height: var(--height-relative);
     width: 30%;

--- a/public/css/home-dark.css
+++ b/public/css/home-dark.css
@@ -52,6 +52,8 @@
     list-style-type: none;
     position: relative;
     align-content: center;
+    display: flex;
+    flex-direction: column;
 }
 
 .home-board
@@ -130,6 +132,29 @@
     box-shadow: inset 0 0 100px 0 darkorange;
     color: black;
 
+}
+
+@media only screen and (max-width: 1536px) 
+{
+    .home-create-board-button
+{
+    width:20vw;
+    height:5vw;
+    position: relative;
+    left: 40%;
+    margin:auto;
+    font-size: large;
+    align-self: center;
+    color: black;
+    transition: ease-out 0.15s;
+}
+    .home-create-board-button:hover
+    {
+        font-size: medium;
+        box-shadow: inset 0 0 100px 0 darkorange;
+        color: black;
+
+    }
 }
 
 .home-board label

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -51,7 +51,8 @@
     list-style-type: none;
     position: relative;
     align-content: center;
-    
+    display: flex;
+    flex-direction: column;
 }
 
 .home-board
@@ -134,6 +135,27 @@
 
 }
 
+@media only screen and (max-width: 1536px) 
+{
+    .home-create-board-button
+    {
+        width:20vw;
+        height:5vw;
+        position: relative;
+        left: 40%;
+        margin:auto;
+        font-size: large;
+        align-self: center;
+
+        transition: ease-out 0.15s;
+    }
+    .home-create-board-button:hover
+    {
+        font-size: medium;
+        box-shadow: inset 0 0 100px 0 darkorange;
+        color: black;
+    }
+}
 .home-board label
 {
     font-size: 1.8em;

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -8,6 +8,8 @@
     width: 150px;
     text-align: center;
     font-size: x-large;
+    color: black;
+    vertical-align: top;
 }
 .form-popup {
     display: none;
@@ -38,4 +40,32 @@
     height: 50px;
     width: 70%;
     font-size: x-large;
+    background-color: lightgoldenrodyellow;
+}
+
+@media only screen and (max-width: 1536px)
+{
+    .update-settings-button { /*not actually a button element so need to keep some button css*/
+        background-color: lightgoldenrodyellow; /*Had to make it explicit for the dark mode to work properly*/
+        color: black;
+        border-radius: 5px;
+        border: 2px solid black;
+        height: 50px;
+        width: 70%;
+        font-size: medium;
+        transition: ease-out 0.15s;
+    }
+    .update-settings-button:hover { /* Default hover effect */
+        box-shadow: inset 0 0 100px 0 rgb(32, 42, 178);
+        color: white;
+        font-size: small;
+    }
+    .close-settings-button {
+        height: 50px;
+        width: 70%;
+        font-size: large;
+        background-color: lightgoldenrodyellow;
+        border-radius: 5px;
+        border: 2px solid black;
+    }
 }


### PR DESCRIPTION
Had to make some adjustments so that styling would look good on an ipad for tomorrow. I used an ipad air 4 for testing.

The safari developer tools on mac are not accurate for emulating what mobile devices look like, so I wouldnt trust that.

The fixes made include making sure the text in buttons doesnt overflow, and when a user chooses to edit a board on the home screen the green box now expands with the size of its contents.

To test on a tablet, just enter the ip address and port number of the computer thats running the docker container into the web browser, and make sure they are both using the same wifi network.